### PR TITLE
Add difficulty selection screen

### DIFF
--- a/jungbo-silgi-2025/ContentView.swift
+++ b/jungbo-silgi-2025/ContentView.swift
@@ -6,61 +6,56 @@
 //
 
 import SwiftUI
-import SwiftData
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
+    @State private var isHigh = false
+    @State private var isMedium = false
+    @State private var isLow = false
 
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
-                    }
-                }
-                .onDelete(perform: deleteItems)
-            }
-#if os(macOS)
-            .navigationSplitViewColumnWidth(min: 180, ideal: 200)
-#endif
-            .toolbar {
-#if os(iOS)
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-#endif
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
-                }
-            }
-        } detail: {
-            Text("Select an item")
-        }
-    }
+        ZStack {
+            LinearGradient(
+                colors: [.blue.opacity(0.2), .purple.opacity(0.2)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
 
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
+            VStack(spacing: 32) {
+                Text("난이도 선택")
+                    .font(.largeTitle.bold())
 
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
+                VStack(alignment: .leading, spacing: 20) {
+                    Toggle("상", isOn: $isHigh)
+                        .toggleStyle(.checkbox)
+
+                    Toggle("중", isOn: $isMedium)
+                        .toggleStyle(.checkbox)
+
+                    Toggle("하", isOn: $isLow)
+                        .toggleStyle(.checkbox)
+                }
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(.thinMaterial)
+                )
+
+                Button(action: {
+                    // 시작 동작 처리
+                }) {
+                    Text("시작")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
             }
+            .padding()
         }
     }
 }
 
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
 }


### PR DESCRIPTION
## Summary
- create a simple difficulty selector in `ContentView`
- provide checkboxes for high, medium, and low
- add a prominent start button at the bottom
- apply a modern look with a gradient background and rounded rectangle container

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project jungbo-silgi-2025.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bca0f10e8832195e89977697dc8ee