### PR TITLE
Add exam question registration UI

### DIFF
--- a/jungbo-silgi-2025/ContentView.swift
+++ b/jungbo-silgi-2025/ContentView.swift
@@ -13,8 +13,9 @@ struct ContentView: View {
     @State private var isLow = false
 
     var body: some View {
-        ZStack {
-            LinearGradient(
+        NavigationStack {
+            ZStack {
+                LinearGradient(
                 colors: [.blue.opacity(0.2), .purple.opacity(0.2)],
                 startPoint: .top,
                 endPoint: .bottom
@@ -52,8 +53,14 @@ struct ContentView: View {
                 .tint(.blue)
             }
             .padding()
+            .toolbar {
+                NavigationLink("문제 등록") {
+                    ExamQuestionRegistrationView()
+                }
+            }
         }
     }
+}
 }
 
 #Preview {

--- a/jungbo-silgi-2025/ExamQuestion.swift
+++ b/jungbo-silgi-2025/ExamQuestion.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SwiftData
+
+@Model
+final class ExamQuestion {
+    @Attribute(.externalStorage) var imageData: Data?
+    var answer: String
+
+    init(imageData: Data? = nil, answer: String = "") {
+        self.imageData = imageData
+        self.answer = answer
+    }
+}

--- a/jungbo-silgi-2025/ExamQuestionRegistrationView.swift
+++ b/jungbo-silgi-2025/ExamQuestionRegistrationView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import PhotosUI
+import SwiftData
+
+struct ExamQuestionRegistrationView: View {
+    @Environment(.modelContext) private var modelContext
+
+    @State private var pickerItems: [PhotosPickerItem] = []
+    @State private var images: [UIImage] = []
+    @State private var answers: [String] = []
+
+    var body: some View {
+        VStack {
+            PhotosPicker("이미지 선택", selection: $pickerItems, maxSelectionCount: 100, matching: .images)
+                .onChange(of: pickerItems) { newItems in
+                    images = []
+                    answers = Array(repeating: "", count: newItems.count)
+                    for (index, item) in newItems.enumerated() {
+                        Task {
+                            if let data = try? await item.loadTransferable(type: Data.self),
+                               let uiImage = UIImage(data: data) {
+                                if images.count <= index { images.append(uiImage) }
+                            }
+                        }
+                    }
+                }
+                .padding()
+
+            List {
+                ForEach(images.indices, id: \.self) { index in
+                    HStack {
+                        Image(uiImage: images[index])
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 80, height: 80)
+                        TextField("정답 입력", text: $answers[index])
+                    }
+                }
+            }
+
+            Button("저장") {
+                for (index, image) in images.enumerated() {
+                    if let data = image.jpegData(compressionQuality: 0.8) {
+                        let question = ExamQuestion(imageData: data, answer: answers[index])
+                        modelContext.insert(question)
+                    }
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+        }
+        .navigationTitle("기출문제 등록")
+    }
+}
+
+#Preview {
+    ExamQuestionRegistrationView()
+}

--- a/jungbo-silgi-2025/jungbo_silgi_2025App.swift
+++ b/jungbo-silgi-2025/jungbo_silgi_2025App.swift
@@ -13,6 +13,7 @@ struct jungbo_silgi_2025App: App {
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Item.self,
+            ExamQuestion.self,
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 


### PR DESCRIPTION
## Summary
- support saving exam questions with answers
- add UI to pick multiple question images and register answers
- expose registration screen via Navigation toolbar
- add new model to data schema

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684bd5f87a4c832196488fd0d3552034